### PR TITLE
reduce number of FetchRequest in SessionView

### DIFF
--- a/CubeTime/Sessions/SessionsView.swift
+++ b/CubeTime/Sessions/SessionsView.swift
@@ -1092,31 +1092,13 @@ struct SessionsView: View {
     
     
     
-    // I know that this is bad
-    // I tried to use SectionedFetchRequest to no avail
-    // send a PR if you can make this good :)
     @FetchRequest(
         entity: Sessions.entity(),
         sortDescriptors: [
-            NSSortDescriptor(keyPath: \Sessions.name, ascending: true)
-        ],
-        predicate: NSPredicate(format: "pinned == YES")
-    ) var pinnedSessions: FetchedResults<Sessions>
-    
-    @FetchRequest(
-        entity: Sessions.entity(),
-        sortDescriptors: [
-            NSSortDescriptor(keyPath: \Sessions.name, ascending: true)
-        ],
-        predicate: NSPredicate(format: "pinned == NO")
-    ) var unPinnedSessions: FetchedResults<Sessions>
-        
-    @FetchRequest(
-        entity: Sessions.entity(),
-        sortDescriptors: [
+            NSSortDescriptor(keyPath: \Sessions.pinned, ascending: false),
             NSSortDescriptor(keyPath: \Sessions.name, ascending: true)
         ]
-    ) var allSessions: FetchedResults<Sessions>
+    ) var sessions: FetchedResults<Sessions>
     
     var body: some View {
         NavigationView {
@@ -1126,13 +1108,8 @@ struct SessionsView: View {
                 
                 ScrollView {
                     VStack (spacing: 10) {
-                        ForEach(pinnedSessions) { item in
-                            SessionCard(currentSession: $currentSession, item: item, numSessions: pinnedSessions.count + unPinnedSessions.count, allSessions: allSessions)
-                                .environment(\.managedObjectContext, managedObjectContext)
-                            
-                        }
-                        ForEach(unPinnedSessions) { item in
-                            SessionCard(currentSession: $currentSession, item: item, numSessions: pinnedSessions.count + unPinnedSessions.count, allSessions: allSessions)
+                        ForEach(sessions) { item in
+                            SessionCard(currentSession: $currentSession, item: item, numSessions: sessions.count, allSessions: sessions)
                                 .environment(\.managedObjectContext, managedObjectContext)
                             
                         }


### PR DESCRIPTION
Hello, thank you for creating such an amazing application 🔥 

As I understand `pinnedSessions` and `unPinnedSessions` was introduced to show pinned on top. If that is the case, why not sort by `pinned` and have one request instead of three? 
